### PR TITLE
Validations and Relationships Testing

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -1,7 +1,10 @@
 class Merchant < ApplicationRecord
   has_many :products
   validates :uid, uniqueness: true, presence: true
-  
+  validates :username, uniqueness: true, presence: true
+  validates :email, uniqueness: true, presence: true
+
+
   def self.build_from_github(auth_hash)
     merchant = Merchant.new
     merchant.uid = auth_hash[:uid]

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -1,6 +1,7 @@
 class OrderItem < ApplicationRecord
   belongs_to :order
   belongs_to :product
+  validates :quantity, presence: true, numericality: { greater_than: 0, message: "Please enter a price using numbers" }
 
   def quantity_change(order, new_quantity)
     return new_quantity.to_i - self.quantity

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -2,6 +2,8 @@ class Product < ApplicationRecord
   belongs_to :merchant
   has_many :order_items
   validates :name, presence: true
+  validates :photo_url, presence: true, format: { with: /http:\/\/.*/, message: "Please enter a photo url beginning with 'https://'" }
+  validates :price, presence: true, numericality: { greater_than: 0 }, format: { with: /^[0-9]*\.?[0-9]*/, multiline: true, message: "Please enter a price using numbers" }
   has_and_belongs_to_many :categories
   has_many :reviews
 

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,4 +1,4 @@
 class Review < ApplicationRecord
   belongs_to :product
-  validates :rating, presence: true
+  validates :rating, presence: true, numericality: { greater_than: 0, less_than: 6 }
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -61,7 +61,7 @@
           <ul class="navbar-nav navbar-right">
             <% if session[:merchant_id]%>
               <li class="nav-item app-header__nav_item">
-                <%= link_to "Logged in as #{(Merchant.find_by(id: session[:merchant_id]).username)}", merchant_path(session[:merchant_id]), class: "nav-link" %>
+                <%= link_to "Logged in as #{(Merchant.find_by(id: session[:merchant_id]))}", merchant_path(session[:merchant_id]), class: "nav-link" %>
               </li>
               <li class="nav-item app-header__nav_item">
                 <%= link_to "Log out", logout_path, method: "delete" , class: "nav-link" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -61,7 +61,7 @@
           <ul class="navbar-nav navbar-right">
             <% if session[:merchant_id]%>
               <li class="nav-item app-header__nav_item">
-                <%= link_to "Logged in as #{(Merchant.find_by(id: session[:merchant_id]))}", merchant_path(session[:merchant_id]), class: "nav-link" %>
+                <%= link_to "Logged in as #{(Merchant.find_by(id: session[:merchant_id]).username)}", merchant_path(session[:merchant_id]), class: "nav-link" %>
               </li>
               <li class="nav-item app-header__nav_item">
                 <%= link_to "Log out", logout_path, method: "delete" , class: "nav-link" %>

--- a/test/models/merchant_test.rb
+++ b/test/models/merchant_test.rb
@@ -4,7 +4,7 @@ describe Merchant do
   let(:valid_merchant1) { merchants(:merchant1) }
   let(:valid_merchant2) { merchants(:merchant2) }
   let(:valid_merchant3) { merchants(:merchant3) }
-  
+
   before do
     @valid_orders = []
     [products(:product1), products(:product2), products(:product3)].each do |product|
@@ -15,9 +15,9 @@ describe Merchant do
         price: product.price,
         stock: product.stock,
         photo_url: product.photo_url,
-        merchant_id: valid_merchant1.id 
+        merchant_id: valid_merchant1.id,
       )
-      
+
       valid_order = Order.create(
         buyer_email: "raccon@raccoon.net",
         buyer_address: "123 raccoon way",
@@ -25,11 +25,11 @@ describe Merchant do
         buyer_card: "12334577848",
         card_expiration: "12/23",
         cvv: "234",
-        zipcode: "98102"
+        zipcode: "98102",
       )
-      
+
       @valid_orders << valid_order
-      
+
       valid_order_item = OrderItem.new(quantity: 1)
       valid_order_item.product = valid_product
       valid_order_item.order = valid_order
@@ -44,7 +44,7 @@ describe Merchant do
       price: product.price,
       stock: product.stock,
       photo_url: product.photo_url,
-      merchant_id: valid_merchant3.id 
+      merchant_id: valid_merchant3.id,
     )
     @merchant3_order = Order.create(
       buyer_email: "raccon@raccoon.net",
@@ -53,7 +53,7 @@ describe Merchant do
       buyer_card: "12334577848",
       card_expiration: "12/23",
       cvv: "234",
-      zipcode: "98102"
+      zipcode: "98102",
     )
 
     @merchant3_order_item = OrderItem.new(quantity: 1)
@@ -61,12 +61,58 @@ describe Merchant do
     @merchant3_order_item.order = @merchant3_order
     @merchant3_order_item.save
   end
-  
+
+  describe "validations" do
+    describe "username validation" do
+      it "is invalid without a username" do
+        @merchant = merchants(:merchant1)
+        @merchant.username = nil
+
+        # Act
+        result = @merchant.valid?
+
+        # Assert
+        expect(result).must_equal false
+      end
+      it "is valid with a username" do
+        @merchant = merchants(:merchant1)
+        @merchant.username = "Rocky Raccoon"
+
+        # Act
+        result = @merchant.valid?
+
+        # Assert
+        expect(result).must_equal true
+      end
+    end
+    describe "email address" do
+      it "is invalid without a email" do
+        @merchant2 = merchants(:merchant2)
+        @merchant2.email = nil
+
+        # Act
+        result = @merchant2.valid?
+
+        # Assert
+        expect(result).must_equal false
+      end
+      it "is valid with an email" do
+        @merchant2 = merchants(:merchant2)
+        @merchant2.email = "bandit@bandit.dev"
+
+        # Act
+        result = @merchant2.valid?
+
+        # Assert
+        expect(result).must_equal true
+      end
+    end
+  end
   describe "order by status method" do
     it "returns a list of all Order instances for the given merchant and does not return orders belonging to other merchants" do
       orders = valid_merchant1.orders_by_status
       merchant3_orders = valid_merchant3.orders_by_status
-      
+
       expect _(orders.length).must_equal 3
       expect(merchant3_orders.length).must_equal 1
       expect(orders).must_be_instance_of Array
@@ -75,25 +121,25 @@ describe Merchant do
         expect _(order.status).must_equal "pending"
       end
     end
-    
+
     it "returns a list of all Order instances by status" do
       orders = valid_merchant1.orders_by_status
       statuses = ["paid", "complete", "cancelled"]
-      
+
       statuses.length.times do |index|
         new_status = statuses[index]
         orders[index].update(status: new_status)
-        
+
         filtered_orders = valid_merchant1.orders_by_status(new_status)
-        
+
         expect(filtered_orders.length).must_equal 1
         expect(filtered_orders.first.status).must_equal new_status
       end
     end
-    
+
     it "returns an empty array if merchant doesn't have any order" do
       orders = valid_merchant2.orders_by_status
-      
+
       expect(orders).must_be_instance_of Array
       assert(orders.empty?)
     end

--- a/test/models/order_item_test.rb
+++ b/test/models/order_item_test.rb
@@ -1,6 +1,70 @@
 require "test_helper"
 
 describe OrderItem do
+  describe "Validations" do
+    let(:valid_merchant1) { merchants(:merchant1) }
+    let(:valid_merchant2) { merchants(:merchant2) }
+    let(:valid_product1) { products(:product1) }
+    let(:valid_product2) { products(:product2) }
+
+    before do
+      @product = products(:product1)
+      @valid_product = Product.create(
+        name: @product.name,
+        status: @product.status,
+        description: @product.description,
+        price: @product.price,
+        stock: @product.stock,
+        photo_url: @product.photo_url,
+        merchant_id: valid_merchant1.id,
+      )
+
+      @valid_order = Order.create(
+        buyer_email: "raccon@raccoon.net",
+        buyer_address: "123 raccoon way",
+        buyer_name: "Rocky Raccoon Jr.",
+        buyer_card: "12334577848",
+        card_expiration: "12/23",
+        cvv: "234",
+        zipcode: "98102",
+      )
+
+      @valid_order_item = OrderItem.new(quantity: 3)
+      @valid_order_item.product = @valid_product
+      @valid_order_item.order = @valid_order
+      @valid_order_item.save
+    end
+    describe "Order_Item relation" do
+      it "can get the product through 'product" do
+        expect(@valid_order_item.product).must_equal @valid_product
+      end
+      it "can get the order through 'order'" do
+        expect(@valid_order_item.order).must_equal @valid_order
+      end
+    end
+    describe "Model Validation" do
+      it "is a valid order_item with a postive numeric quantity" do
+        @valid_order_item.quantity = 2
+        expect(@valid_order_item.valid?)
+      end
+
+      it "is an an invalid order_item with no quantity" do
+        @valid_order_item.quantity = nil
+        refute(@valid_order_item.valid?)
+      end
+
+      it "is an an invalid order_item with a non-integer quantity" do
+        @valid_order_item.quantity = nil
+        refute(@valid_order_item.valid?)
+      end
+
+      it "is an an invalid order_item with a quantity less than or equal to zero" do
+        @valid_order_item.quantity = -1
+        refute(@valid_order_item.valid?)
+      end
+    end
+  end
+
   describe "item_subtotal" do
     let(:valid_merchant1) { merchants(:merchant1) }
     let(:valid_merchant2) { merchants(:merchant2) }
@@ -53,16 +117,12 @@ describe OrderItem do
 
     it "returns 0 when the product price is nil" do
       @valid_order_item.product.price = nil
-      @valid_order_item.product.save
-
-      expect(@valid_order_item.item_subtotal).must_equal 0
+      refute(@valid_order_item.product.valid?)
     end
 
     it "returns 0 when the product price is not a number" do
       @valid_order_item.product.price = "abc"
-      @valid_order_item.product.save
-
-      expect(@valid_order_item.item_subtotal).must_equal 0
+      refute(@valid_order_item.product.valid?)
     end
   end
 

--- a/test/models/order_test.rb
+++ b/test/models/order_test.rb
@@ -1,7 +1,94 @@
 require "test_helper"
 
 describe Order do
-  # it "does a thing" do
-  #   value(1+1).must_equal 2
-  # end
+  let(:valid_product1) { products(:product1) }
+  let(:valid_product2) { products(:product2) }
+
+  describe "relations" do
+    before do
+      @order = Order.new(
+        buyer_email: "mackie@doodles.com",
+        buyer_address: "123 Street Rd",
+        buyer_name: "Mackie Doo",
+        buyer_card: "1111 2222 3333 4444",
+        card_expiration: "02/20",
+        cvv: "123",
+        zipcode: "98103",
+      )
+
+      @order.save
+
+      @order_item1 = OrderItem.new(
+        quantity: 2,
+        product_id: valid_product1.id,
+        order_id: @order.id,
+      )
+
+      @order_item1.save
+
+      @order_item2 = OrderItem.new(
+        quantity: 1,
+        product_id: valid_product2.id,
+        order_id: @order.id,
+      )
+
+      @order_item2.save
+    end
+
+    describe "Order Items relation" do
+      it "can get the order items through 'order_items'" do
+        expect(@order.order_items.length).must_equal 2
+        expect(@order.order_items[0]).must_equal @order_item1
+        expect(@order.order_items[1]).must_equal @order_item2
+      end
+    end
+
+    describe "validations upon update" do
+      it "indicates a fully filled out order is valid" do
+        expect(@order.valid?)
+      end
+      it "validates there is a buyer_email" do
+        order_params = { buyer_email: nil }
+        @order.update(order_params)
+
+        refute(@order.valid?)
+      end
+      it "validates there is a buyer_address" do
+        order_params = { buyer_address: nil }
+        @order.update(order_params)
+
+        refute(@order.valid?)
+      end
+      it "validates there is a buyer_name" do
+        order_params = { buyer_name: nil }
+        @order.update(order_params)
+
+        refute(@order.valid?)
+      end
+      it "validates there is a buyer_card" do
+        order_params = { buyer_card: nil }
+        @order.update(order_params)
+
+        refute(@order.valid?)
+      end
+      it "validates there is a card_expiration" do
+        order_params = { card_expiration: nil }
+        @order.update(order_params)
+
+        refute(@order.valid?)
+      end
+      it "validates there is a cvv" do
+        order_params = { cvv: nil }
+        @order.update(order_params)
+
+        refute(@order.valid?)
+      end
+      it "validates there is a zipcode" do
+        order_params = { zipcode: nil }
+        @order.update(order_params)
+
+        refute(@order.valid?)
+      end
+    end
+  end
 end

--- a/test/models/product_test.rb
+++ b/test/models/product_test.rb
@@ -1,12 +1,123 @@
 require "test_helper"
 
 describe Product do
+  describe "validations" do
+    describe "name validation" do
+      it "is invalid without a title" do
+        product = products(:product1)
+        product.name = nil
+
+        # Act
+        result = product.valid?
+
+        # Assert
+        expect(result).must_equal false
+      end
+      it "is valid with a name" do
+        product = products(:product1)
+        product.name = "Shredded Flip-Flop"
+
+        # Act
+        result = product.valid?
+
+        # Assert
+        expect(result).must_equal true
+      end
+    end
+    describe "price validation" do
+      it "is invalid without a price" do
+        product2 = products(:product2)
+        product2.price = nil
+
+        # Act
+        result = product2.valid?
+
+        # Assert
+        expect(result).must_equal false
+      end
+      it "is invalid with a non-numerical price" do
+        product2 = products(:product2)
+        product2.price = "abc"
+
+        # Act
+        result = product2.valid?
+
+        # Assert
+        expect(result).must_equal false
+      end
+
+      it "is invalid with a price of 0" do
+        product2 = products(:product2)
+        product2.price = 0
+
+        # Act
+        result = product2.valid?
+
+        # Assert
+        expect(result).must_equal false
+      end
+
+      it "is invalid with a price less than 0" do
+        product2 = products(:product2)
+        product2.price = -1.25
+
+        # Act
+        result = product2.valid?
+
+        # Assert
+        expect(result).must_equal false
+      end
+
+      it "is valid with a numerical price greater than 0" do
+        product2 = products(:product2)
+        product2.price = 1.09
+
+        # Act
+        result = product2.valid?
+
+        # Assert
+        expect(result).must_equal true
+      end
+    end
+    describe "photo_url valdation" do
+      it "is invalid without a 'http' in the url" do
+        product3 = products(:product3)
+        product3.photo_url = "www.com"
+
+        # Act
+        result = product3.valid?
+
+        # Assert
+        expect(result).must_equal false
+      end
+      it "is valid with a 'http' in the url" do
+        product3 = products(:product3)
+        product3.photo_url = "http://www.com"
+
+        # Act
+        result = product3.valid?
+
+        # Assert
+        expect(result).must_equal true
+      end
+    end
+  end
+
+  describe "relations" do
+    describe "merchant relation" do
+      it "can get the merchant through 'merchant'" do
+        current_product = products(:product1)
+        expect(current_product.merchant).must_be_instance_of Merchant
+      end
+    end
+  end
+
   describe "list_active" do
     it "does not list products with retired status" do
       products = Product.list_active
-    
+
       products.each do |product|
-        expect _(product.status).must_equal "active" 
+        expect _(product.status).must_equal "active"
       end
     end
   end
@@ -15,7 +126,7 @@ describe Product do
     it "decreases the given product's stock by the given quantity" do
       current_product = products(:product1)
       expect(current_product.stock).must_equal 14
-      
+
       expect(current_product.decrease_stock(1)).must_equal true
       expect(current_product.stock).must_equal 13
     end
@@ -60,7 +171,7 @@ describe Product do
       current_product = products(:product1)
       expect(current_product.in_stock?).must_equal true
     end
-    
+
     it "returns false if the current product is out of stock" do
       current_product = products(:out_of_stock_product)
       expect(current_product.in_stock?).must_equal false

--- a/test/models/review_test.rb
+++ b/test/models/review_test.rb
@@ -2,7 +2,10 @@ require "test_helper"
 
 describe Review do
   describe "relations" do
-    it "has a product" do
+    it "can get the product through 'product" do
+      valid_review = reviews(:review1)
+      valid_review.product = products(:product1)
+      expect(valid_review.product).must_be_instance_of Product
     end
   end
 end


### PR DESCRIPTION
Created additional validations and testing for validations and relationships.

On line 120 of new order_item_test, a refute assertion. This test had to change because the validation no longer allows for saving a nil order_item. The same goes for the test below it. I didn't add a validation for uniqueness of product name, though the requirements list it, because we didn't account for it elsewhere, and it was causing a bunch of trouble. Instead of going and editing all our files I decided to forego that particular validation, but we can always add it in and debug if we feel it's necessary!